### PR TITLE
Add hashing to Auth0UserBasic

### DIFF
--- a/src/main/java/com/dataloom/directory/pojo/Auth0UserBasic.java
+++ b/src/main/java/com/dataloom/directory/pojo/Auth0UserBasic.java
@@ -93,4 +93,28 @@ public class Auth0UserBasic {
                 ", organizations=" + organizations +
                 '}';
     }
+
+    @Override
+    public int hashCode() {
+        //user id is a unique identifier.
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( userId == null ) ? 0 : userId.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        //user id is a unique identifier.
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        Auth0UserBasic other = (Auth0UserBasic) obj;
+        if ( userId == null ) {
+            if ( other.userId != null ) return false;
+        } else if ( !userId.equals( other.userId ) ) return false;
+        return true;
+    }
+    
+    
 }


### PR DESCRIPTION
Please first see a related PR in conductor-client: https://github.com/dataloom/conductor-client/pull/95

Auth0UserBasic is currently missing the hash method. This may cause duplicates when calling `getAllUsers` in `UserDirectoryService`, which may cause error when collecting them into a map due to duplicate keys:
https://github.com/dataloom/conductor-client/blob/e11942ec802af026d5e299e1247736d4bd6874f1/src/main/java/com/dataloom/directory/UserDirectoryService.java#L77