### PR TITLE
Feature/backend 847

### DIFF
--- a/src/main/java/com/dataloom/authorization/AuthorizationsApi.java
+++ b/src/main/java/com/dataloom/authorization/AuthorizationsApi.java
@@ -1,18 +1,34 @@
 package com.dataloom.authorization;
 
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+
+import com.dataloom.authorization.securable.SecurableObjectType;
 
 import retrofit2.http.Body;
+import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Query;
 
 public interface AuthorizationsApi {
     /*
      * These determine the service routing for the LB
      */
-    String SERVICE                 = "/datastore";
-    String CONTROLLER              = "/authorizations";
-    String BASE                    = SERVICE + CONTROLLER;
-    
+    String SERVICE      = "/datastore";
+    String CONTROLLER   = "/authorizations";
+    String BASE         = SERVICE + CONTROLLER;
+
+    String OBJECT_TYPE  = "objectType";
+    String PERMISSION   = "permission";
+    String PAGING_STATE = "next";
+
     @POST( BASE )
     Iterable<Authorization> checkAuthorizations( @Body Set<AccessCheck> queries );
+
+    @GET( BASE )
+    Iterable<List<UUID>> getAccessibleObjects(
+            @Query( OBJECT_TYPE ) SecurableObjectType type,
+            @Query( PERMISSION ) Permission permission );
+
 }

--- a/src/main/java/com/dataloom/authorization/AuthorizationsApi.java
+++ b/src/main/java/com/dataloom/authorization/AuthorizationsApi.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import com.dataloom.authorization.paging.AuthorizedObjectsSearchResult;
 import com.dataloom.authorization.securable.SecurableObjectType;
 
 import retrofit2.http.Body;
@@ -21,14 +22,15 @@ public interface AuthorizationsApi {
 
     String OBJECT_TYPE  = "objectType";
     String PERMISSION   = "permission";
-    String PAGING_STATE = "next";
+    String PAGING_TOKEN = "pagingToken";
 
     @POST( BASE )
     Iterable<Authorization> checkAuthorizations( @Body Set<AccessCheck> queries );
 
     @GET( BASE )
-    Iterable<List<UUID>> getAccessibleObjects(
-            @Query( OBJECT_TYPE ) SecurableObjectType type,
-            @Query( PERMISSION ) Permission permission );
+    AuthorizedObjectsSearchResult getAccessibleObjects(
+            @Query( OBJECT_TYPE ) SecurableObjectType objectType,
+            @Query( PERMISSION ) Permission permission,
+            @Query( PAGING_TOKEN ) String pagingToken );
 
 }

--- a/src/main/java/com/dataloom/authorization/Principal.java
+++ b/src/main/java/com/dataloom/authorization/Principal.java
@@ -6,7 +6,7 @@ import com.dataloom.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Principal implements Serializable {
+public class Principal implements Comparable<Principal>, Serializable {
     private static final long   serialVersionUID = 3227310509765475747L;
 
     private final PrincipalType type;
@@ -56,6 +56,17 @@ public class Principal implements Serializable {
     @Override
     public String toString() {
         return "Principal [type=" + type + ", id=" + id + "]";
+    }
+
+    @Override
+    public int compareTo( Principal o ) {
+        int result = type.compareTo( o.getType() );
+        
+        if( result == 0){
+            result = id.compareTo( o.getId() );
+        }
+        
+        return result;
     }
 
 }

--- a/src/main/java/com/dataloom/authorization/paging/AuthorizedObjectsSearchResult.java
+++ b/src/main/java/com/dataloom/authorization/paging/AuthorizedObjectsSearchResult.java
@@ -1,0 +1,35 @@
+package com.dataloom.authorization.paging;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthorizedObjectsSearchResult {
+    private String          pagingToken;
+    private Set<List<UUID>> authorizedObjects;
+
+    public AuthorizedObjectsSearchResult( String pagingToken, Set<List<UUID>> authorizedObjects ) {
+        this.pagingToken = pagingToken;
+        this.authorizedObjects = authorizedObjects;
+    }
+
+    @JsonProperty( SerializationConstants.PAGING_TOKEN )
+    public String getPagingToken() {
+        return pagingToken;
+    }
+
+    @JsonProperty( SerializationConstants.AUTHORIZED_OBJECTS )
+    public Set<List<UUID>> getAuthorizedObjects() {
+        return authorizedObjects;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizedObjectsSearchResult [pagingToken=" + pagingToken + ", authorizedObjects=" + authorizedObjects
+                + "]";
+    }
+
+}

--- a/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
+++ b/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
@@ -105,4 +105,6 @@ public final class SerializationConstants {
     public static final String PII_FIELD                   = "piiField";
     public static final String ANALYZER                    = "analyzer";
 
+    public static final String CONTACTS                    = "contacts";
+
 }

--- a/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
+++ b/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
@@ -107,4 +107,7 @@ public final class SerializationConstants {
 
     public static final String CONTACTS                    = "contacts";
 
+    public static final String PAGING_TOKEN                = "pagingToken";
+    public static final String AUTHORIZED_OBJECTS          = "authorizedObjects";
+
 }

--- a/src/main/java/com/dataloom/edm/EntitySet.java
+++ b/src/main/java/com/dataloom/edm/EntitySet.java
@@ -57,13 +57,14 @@ public class EntitySet extends AbstractSecurableObject {
             @JsonProperty( SerializationConstants.NAME_FIELD ) String name,
             @JsonProperty( SerializationConstants.TITLE_FIELD ) String title,
             @JsonProperty( SerializationConstants.DESCRIPTION_FIELD ) Optional<String> description,
-            @JsonProperty( SerializationConstants.CONTACTS ) Optional<Set<String>> contacts) {
+            @JsonProperty( SerializationConstants.CONTACTS ) Set<String> contacts ) {
         super( id, title, description );
         checkArgument( StringUtils.isNotBlank( name ), "Entity set name cannot be blank." );
         checkArgument( StringUtils.isNotBlank( title ), "Entity set title cannot be blank." );
+        checkArgument( contacts != null && !contacts.isEmpty(), "Contacts cannot be blank." );
         this.name = name;
         this.entityTypeId = checkNotNull( entityTypeId );
-        this.contacts = contacts.or( ImmutableSet.of() );
+        this.contacts = contacts;
     }
 
     public EntitySet(
@@ -72,7 +73,7 @@ public class EntitySet extends AbstractSecurableObject {
             String name,
             String title,
             Optional<String> description,
-            Optional<Set<String>> contacts ) {
+            Set<String> contacts ) {
         this( Optional.of( id ), entityTypeId, name, title, description, contacts );
     }
 
@@ -81,7 +82,7 @@ public class EntitySet extends AbstractSecurableObject {
             String name,
             String title,
             Optional<String> description,
-            Optional<Set<String>> contacts ) {
+            Set<String> contacts ) {
         this( Optional.absent(), entityTypeId, name, title, description, contacts );
     }
 

--- a/src/main/java/com/dataloom/edm/EntitySet.java
+++ b/src/main/java/com/dataloom/edm/EntitySet.java
@@ -20,6 +20,7 @@ package com.dataloom.edm;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Set;
 import java.util.UUID;
 
 import com.dataloom.authorization.securable.AbstractSecurableObject;
@@ -30,6 +31,7 @@ import com.dataloom.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@kryptnostic.com&gt;
@@ -38,6 +40,7 @@ import com.google.common.base.Optional;
 public class EntitySet extends AbstractSecurableObject {
     private final UUID   entityTypeId;
     private final String name;
+    private final Set<String> contacts;
 
     /**
      * Creates an entity set with provided parameters and will automatically generate a UUID if not provided.
@@ -53,12 +56,14 @@ public class EntitySet extends AbstractSecurableObject {
             @JsonProperty( SerializationConstants.ENTITY_TYPE_ID_FIELD ) UUID entityTypeId,
             @JsonProperty( SerializationConstants.NAME_FIELD ) String name,
             @JsonProperty( SerializationConstants.TITLE_FIELD ) String title,
-            @JsonProperty( SerializationConstants.DESCRIPTION_FIELD ) Optional<String> description ) {
+            @JsonProperty( SerializationConstants.DESCRIPTION_FIELD ) Optional<String> description,
+            @JsonProperty( SerializationConstants.CONTACTS ) Optional<Set<String>> contacts) {
         super( id, title, description );
         checkArgument( StringUtils.isNotBlank( name ), "Entity set name cannot be blank." );
         checkArgument( StringUtils.isNotBlank( title ), "Entity set title cannot be blank." );
         this.name = name;
         this.entityTypeId = checkNotNull( entityTypeId );
+        this.contacts = contacts.or( ImmutableSet.of() );
     }
 
     public EntitySet(
@@ -66,16 +71,18 @@ public class EntitySet extends AbstractSecurableObject {
             UUID entityTypeId,
             String name,
             String title,
-            Optional<String> description ) {
-        this( Optional.of( id ), entityTypeId, name, title, description );
+            Optional<String> description,
+            Optional<Set<String>> contacts ) {
+        this( Optional.of( id ), entityTypeId, name, title, description, contacts );
     }
 
     public EntitySet(
             UUID entityTypeId,
             String name,
             String title,
-            Optional<String> description ) {
-        this( Optional.absent(), entityTypeId, name, title, description );
+            Optional<String> description,
+            Optional<Set<String>> contacts ) {
+        this( Optional.absent(), entityTypeId, name, title, description, contacts );
     }
 
     public UUID getEntityTypeId() {
@@ -86,12 +93,17 @@ public class EntitySet extends AbstractSecurableObject {
         return name;
     }
 
+    public Set<String> getContacts() {
+        return contacts;
+    }
+    
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ( ( entityTypeId == null ) ? 0 : entityTypeId.hashCode() );
         result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        result = prime * result + ( ( contacts == null ) ? 0 : contacts.hashCode() );
         return result;
     }
 
@@ -121,12 +133,19 @@ public class EntitySet extends AbstractSecurableObject {
         } else if ( !name.equals( other.name ) ) {
             return false;
         }
+        if ( contacts == null ) {
+            if ( other.contacts != null ) {
+                return false;
+            }
+        } else if ( !contacts.equals( other.contacts ) ) {
+            return false;
+        }
         return true;
     }
 
     @Override
     public String toString() {
-        return "EntitySet [entityTypeId=" + entityTypeId + ", name=" + name + ", id=" + id
+        return "EntitySet [entityTypeId=" + entityTypeId + ", name=" + name + ", contacts=" + contacts + ", id=" + id
                 + ", title=" + title + ", description=" + description + "]";
     }
 

--- a/src/main/java/com/dataloom/mapstores/TestDataFactory.java
+++ b/src/main/java/com/dataloom/mapstores/TestDataFactory.java
@@ -80,7 +80,7 @@ public final class TestDataFactory {
                 RandomStringUtils.randomAlphanumeric( 5 ),
                 RandomStringUtils.randomAlphanumeric( 5 ),
                 Optional.of( RandomStringUtils.randomAlphanumeric( 5 ) ),
-                Optional.of( ImmutableSet.of( email(), email() ) ) );
+                ImmutableSet.of( email(), email() ) );
     }
 
     public static PropertyType propertyType() {

--- a/src/main/java/com/dataloom/mapstores/TestDataFactory.java
+++ b/src/main/java/com/dataloom/mapstores/TestDataFactory.java
@@ -32,7 +32,7 @@ public final class TestDataFactory {
     private static final Permission[]          permissions          = Permission.values();
     private static final Action[]              actions              = Action.values();
     private static final RequestStatus[]       requestStatuses      = RequestStatus.values();
-    private static final Analyzer[] analyzers = Analyzer.values();
+    private static final Analyzer[]            analyzers            = Analyzer.values();
     private static final Random                r                    = new Random();
 
     private TestDataFactory() {}
@@ -65,6 +65,10 @@ public final class TestDataFactory {
                 RandomStringUtils.randomAlphanumeric( 5 ) );
     }
 
+    public static String email() {
+        return RandomStringUtils.randomAlphanumeric( 5 ) + "@" + RandomStringUtils.randomAlphanumeric( 5 ) + ".com";
+    }
+
     public static String name() {
         return RandomStringUtils.randomAlphanumeric( 5 );
     }
@@ -75,7 +79,8 @@ public final class TestDataFactory {
                 UUID.randomUUID(),
                 RandomStringUtils.randomAlphanumeric( 5 ),
                 RandomStringUtils.randomAlphanumeric( 5 ),
-                Optional.of( RandomStringUtils.randomAlphanumeric( 5 ) ) );
+                Optional.of( RandomStringUtils.randomAlphanumeric( 5 ) ),
+                Optional.of( ImmutableSet.of( email(), email() ) ) );
     }
 
     public static PropertyType propertyType() {
@@ -87,7 +92,7 @@ public final class TestDataFactory {
                 ImmutableSet.of(),
                 EdmPrimitiveTypeKind.String,
                 Optional.of( r.nextBoolean() ),
-                Optional.of(                 analyzers[ r.nextInt( analyzers.length ) ] ));
+                Optional.of( analyzers[ r.nextInt( analyzers.length ) ] ) );
     }
 
     public static Organization organization() {


### PR DESCRIPTION
- add contacts field (`Set<String>`) to `EntitySet`
- update TestDataFactory to generate Entity Set with contacts field
- make `Principal` comparable
- add endpoint to AuthorizationsApi that returns all authorized objects of a certain SecurableObjectType and certain Permission