### PR TITLE
[do not merge] Bugfix/backend 845

### DIFF
--- a/src/main/java/com/dataloom/authorization/AceExplanation.java
+++ b/src/main/java/com/dataloom/authorization/AceExplanation.java
@@ -3,15 +3,19 @@ package com.dataloom.authorization;
 import java.util.Set;
 
 import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AceExplanation {
     private final Ace      ace;
-    // Explain where the ace comes from.
+    // Explains where the ace comes from.
     private final Set<Ace> explanation;
     private transient int  h = 0;
 
-    public AceExplanation( Ace ace, Set<Ace> explanation ) {
+    @JsonCreator
+    public AceExplanation( 
+            @JsonProperty( SerializationConstants.ACE ) Ace ace, 
+            @JsonProperty( SerializationConstants.EXPLANATION ) Set<Ace> explanation ) {
         this.ace = ace;
         this.explanation = explanation;
     }

--- a/src/main/java/com/dataloom/authorization/AceExplanation.java
+++ b/src/main/java/com/dataloom/authorization/AceExplanation.java
@@ -1,0 +1,65 @@
+package com.dataloom.authorization;
+
+import java.util.Set;
+
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AceExplanation {
+    private final Ace      ace;
+    // Explain where the ace comes from.
+    private final Set<Ace> explanation;
+    private transient int  h = 0;
+
+    public AceExplanation( Ace ace, Set<Ace> explanation ) {
+        this.ace = ace;
+        this.explanation = explanation;
+    }
+
+    @JsonProperty( SerializationConstants.ACE )
+    public Ace getAce() {
+        return ace;
+    }
+
+    @JsonProperty( SerializationConstants.EXPLANATION )
+    public Set<Ace> getExplanation() {
+        return explanation;
+    }
+
+    public void addExplanation( Ace ace ) {
+        explanation.add( ace );
+    }
+
+    @Override
+    public int hashCode() {
+        if ( h == 0 ) {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ( ( ace == null ) ? 0 : ace.hashCode() );
+            result = prime * result + ( ( explanation == null ) ? 0 : explanation.hashCode() );
+            h = result;
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        AceExplanation other = (AceExplanation) obj;
+        if ( ace == null ) {
+            if ( other.ace != null ) return false;
+        } else if ( !ace.equals( other.ace ) ) return false;
+        if ( explanation == null ) {
+            if ( other.explanation != null ) return false;
+        } else if ( !explanation.equals( other.explanation ) ) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "AceExplained [ace=" + ace + ", explanation=" + explanation + "]";
+    }
+
+}

--- a/src/main/java/com/dataloom/authorization/AclExplanation.java
+++ b/src/main/java/com/dataloom/authorization/AclExplanation.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class AclExplanation {
@@ -11,9 +12,10 @@ public class AclExplanation {
     protected final Iterable<AceExplanation> aces;
     private transient int                  h = 0;
 
+    @JsonCreator
     public AclExplanation(
-            List<UUID> aclKey,
-            Iterable<AceExplanation> aces ) {
+            @JsonProperty( SerializationConstants.ACL_OBJECT_PATH ) List<UUID> aclKey,
+            @JsonProperty( SerializationConstants.ACES ) Iterable<AceExplanation> aces ) {
         this.aclKey = aclKey;
         this.aces = aces;
     }

--- a/src/main/java/com/dataloom/authorization/AclExplanation.java
+++ b/src/main/java/com/dataloom/authorization/AclExplanation.java
@@ -1,0 +1,63 @@
+package com.dataloom.authorization;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AclExplanation {
+    protected final List<UUID>             aclKey;
+    protected final Iterable<AceExplanation> aces;
+    private transient int                  h = 0;
+
+    public AclExplanation(
+            List<UUID> aclKey,
+            Iterable<AceExplanation> aces ) {
+        this.aclKey = aclKey;
+        this.aces = aces;
+    }
+
+    @JsonProperty( SerializationConstants.ACL_OBJECT_PATH )
+    public List<UUID> getAclKey() {
+        return aclKey;
+    }
+
+    @JsonProperty( SerializationConstants.ACES )
+    public Iterable<AceExplanation> getAces() {
+        return aces;
+    }
+
+    @Override
+    public int hashCode() {
+        if ( h == 0 ) {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ( ( aces == null ) ? 0 : aces.hashCode() );
+            result = prime * result + ( ( aclKey == null ) ? 0 : aclKey.hashCode() );
+            h = result;
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        AclExplanation other = (AclExplanation) obj;
+        if ( aces == null ) {
+            if ( other.aces != null ) return false;
+        } else if ( !aces.equals( other.aces ) ) return false;
+        if ( aclKey == null ) {
+            if ( other.aclKey != null ) return false;
+        } else if ( !aclKey.equals( other.aclKey ) ) return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "AclExplained [aclKey=" + aclKey + ", aces=" + aces + "]";
+    }
+
+}

--- a/src/main/java/com/dataloom/authorization/PermissionsApi.java
+++ b/src/main/java/com/dataloom/authorization/PermissionsApi.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 import retrofit2.http.Body;
-import retrofit2.http.HTTP;
 import retrofit2.http.PATCH;
 import retrofit2.http.POST;
 
@@ -19,6 +18,8 @@ public interface PermissionsApi {
     String SERVICE    = "/datastore";
     String CONTROLLER = "/permissions";
     String BASE       = SERVICE + CONTROLLER;
+
+    String EXPLAIN    = "/explain";
 
     /**
      * Add, removes, or sets the ace for a particular acl key. Successful only if user is the owner of acl key.
@@ -37,4 +38,15 @@ public interface PermissionsApi {
      */
     @POST( BASE )
     Acl getAcl( @Body List<UUID> aclKey );
+
+    /**
+     * Retrieves the acl for a particular acl key, with explanation of where the permissions come from. Only return if
+     * user is the owner of acl key.
+     * 
+     * @param aclKey The acl key.
+     * @return The aces for the requested acl key, together with the explanation.
+     */
+    @POST( BASE + EXPLAIN )
+    AclExplanation getAclExplanation( @Body List<UUID> aclKey );
+
 }

--- a/src/main/java/com/dataloom/authorization/securable/SecurableObjectType.java
+++ b/src/main/java/com/dataloom/authorization/securable/SecurableObjectType.java
@@ -22,5 +22,6 @@ public enum SecurableObjectType {
     EntitySet,
     PropertyTypeInEntitySet,
     Datasource,
-    Organization
+    Organization,
+    OrganizationRole
 }

--- a/src/main/java/com/dataloom/client/LoomClient.java
+++ b/src/main/java/com/dataloom/client/LoomClient.java
@@ -29,14 +29,14 @@ public class LoomClient implements ApiFactoryFactory {
     public LoomClient( Environment environment, SerializableSupplier<String> jwtToken ) {
         this( () -> {
             final Retrofit retrofit = RetrofitFactory.newClient( environment, jwtToken );
-            return (ApiFactory) retrofit::create;
+            return (ApiFactory) clazz -> retrofit.create( clazz );
         } );
     }
 
     public LoomClient( SerializableSupplier<String> jwtToken ) {
         this( () -> {
             final Retrofit retrofit = RetrofitFactory.newClient( jwtToken );
-            return (ApiFactory) retrofit::create;
+            return (ApiFactory) clazz -> retrofit.create( clazz );
         } );
     }
 

--- a/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
+++ b/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
@@ -118,4 +118,9 @@ public final class SerializationConstants {
     public static final String PARENT_TYPE_FIELD           = "parentType";
 
     public static final String BASE_TYPE_FIELD             = "baseType";
+
+    public static final String ERROR                       = "error";
+    public static final String ERRORS                      = "errors";
+    public static final String MESSAGE                     = "message";
+    public static final String HTTP_STATUS_CODE            = "code";
 }

--- a/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
+++ b/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
@@ -126,4 +126,6 @@ public final class SerializationConstants {
 
     public static final String NAMESPACE                   = "namespace";
     public static final String NAME                        = "name";
+
+    public static final String EXPLANATION                 = "explanation";
 }

--- a/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
+++ b/src/main/java/com/dataloom/client/serialization/SerializationConstants.java
@@ -112,4 +112,5 @@ public final class SerializationConstants {
 
     public static final String REASON                      = "reason";
 
+    public static final String ORGANIZATION_ID                      = "organizationId";
 }

--- a/src/main/java/com/dataloom/directory/PrincipalApi.java
+++ b/src/main/java/com/dataloom/directory/PrincipalApi.java
@@ -3,12 +3,15 @@ package com.dataloom.directory;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import com.dataloom.directory.pojo.Auth0UserBasic;
+import com.dataloom.organization.roles.OrganizationRole;
 
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
+import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
 
@@ -35,6 +38,8 @@ public interface PrincipalApi {
     String ROLES        = "/roles";
     String SEARCH       = "/search";
     String USERS        = "/users";
+    String TITLE       = "/title";
+    String DESCRIPTION        = "/description";
 
     String SEARCH_EMAIL = SEARCH + EMAIL;
 
@@ -47,30 +52,43 @@ public interface PrincipalApi {
     String SEARCH_QUERY_PATH       = "/{" + SEARCH_QUERY + "}";
     String EMAIL_SEARCH_QUERY_PATH = "/{" + SEARCH_QUERY + ":.+" + "}";
 
+    // Endpoints about users
     @GET( BASE + USERS )
     Map<String, Auth0UserBasic> getAllUsers();
 
     @GET( BASE + USERS + USER_ID_PATH )
     Auth0UserBasic getUser( @Path( USER_ID ) String userId );
 
-    @PUT( BASE + USERS + USER_ID_PATH + ROLES )
-    Void setUserRoles( @Path( USER_ID ) String userId, @Body Set<String> roles );
-
     @PUT( BASE + USERS + USER_ID_PATH + ROLES + ROLE_PATH )
-    Void addRoleToUser( @Path( USER_ID ) String userId, @Path( ROLE ) String role );
+    Void addRoleToUser( @Path( USER_ID ) String userId, @Path( ROLE ) String roleIdString );
 
     @DELETE( BASE + USERS + USER_ID_PATH + ROLES + ROLE_PATH )
-    Void removeRoleFromUser( @Path( USER_ID ) String userId, @Path( ROLE ) String role );
-
-    @GET( BASE + ROLES )
-    Map<String, List<Auth0UserBasic>> getAllUsersGroupByRole();
-
-    @GET( BASE + ROLES + ROLE_PATH )
-    List<Auth0UserBasic> getAllUsersOfRole( @Path( ROLE ) String role );
+    Void removeRoleFromUser( @Path( USER_ID ) String userId, @Path( ROLE ) String roleIdString );
 
     @GET( BASE + USERS + SEARCH + SEARCH_QUERY_PATH )
     Map<String, Auth0UserBasic> searchAllUsers( @Path( SEARCH_QUERY ) String searchQuery );
 
     @GET( BASE + USERS + SEARCH_EMAIL + EMAIL_SEARCH_QUERY_PATH )
     Map<String, Auth0UserBasic> searchAllUsersByEmail( @Path( SEARCH_QUERY ) String emailSearchQuery );
+    
+    // Endpoints about roles
+    @POST( BASE + ROLES )
+    String createRole( @Body OrganizationRole role );
+
+    @GET( BASE + ROLES )
+    Iterable<OrganizationRole> getAllRoles();
+    
+    @GET( BASE + ROLES + ROLE_PATH )
+    List<Auth0UserBasic> getAllUsersOfRole( @Path( ROLE ) String roleIdString );
+
+    @PUT( BASE + ROLES + ROLE_PATH + TITLE )
+    Void updateTitle( @Path( ROLE ) String roleIdString, @Body String title );
+
+    @PUT( BASE + ROLES + ROLE_PATH + DESCRIPTION )
+    Void updateDescription( @Path( ROLE ) String roleIdString, @Body String description );
+
+    @DELETE( BASE + ROLES + ROLE_PATH )
+    Void deleteRole( @Path( ROLE ) String roleIdStrin );
+    
+    
 }

--- a/src/main/java/com/dataloom/directory/PrincipalApi.java
+++ b/src/main/java/com/dataloom/directory/PrincipalApi.java
@@ -3,15 +3,12 @@ package com.dataloom.directory;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import com.dataloom.directory.pojo.Auth0UserBasic;
-import com.dataloom.organization.roles.OrganizationRole;
 
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
-import retrofit2.http.POST;
 import retrofit2.http.PUT;
 import retrofit2.http.Path;
 
@@ -38,8 +35,6 @@ public interface PrincipalApi {
     String ROLES        = "/roles";
     String SEARCH       = "/search";
     String USERS        = "/users";
-    String TITLE       = "/title";
-    String DESCRIPTION        = "/description";
 
     String SEARCH_EMAIL = SEARCH + EMAIL;
 
@@ -52,43 +47,15 @@ public interface PrincipalApi {
     String SEARCH_QUERY_PATH       = "/{" + SEARCH_QUERY + "}";
     String EMAIL_SEARCH_QUERY_PATH = "/{" + SEARCH_QUERY + ":.+" + "}";
 
-    // Endpoints about users
     @GET( BASE + USERS )
     Map<String, Auth0UserBasic> getAllUsers();
 
     @GET( BASE + USERS + USER_ID_PATH )
     Auth0UserBasic getUser( @Path( USER_ID ) String userId );
 
-    @PUT( BASE + USERS + USER_ID_PATH + ROLES + ROLE_PATH )
-    Void addRoleToUser( @Path( USER_ID ) String userId, @Path( ROLE ) String roleIdString );
-
-    @DELETE( BASE + USERS + USER_ID_PATH + ROLES + ROLE_PATH )
-    Void removeRoleFromUser( @Path( USER_ID ) String userId, @Path( ROLE ) String roleIdString );
-
     @GET( BASE + USERS + SEARCH + SEARCH_QUERY_PATH )
     Map<String, Auth0UserBasic> searchAllUsers( @Path( SEARCH_QUERY ) String searchQuery );
 
     @GET( BASE + USERS + SEARCH_EMAIL + EMAIL_SEARCH_QUERY_PATH )
     Map<String, Auth0UserBasic> searchAllUsersByEmail( @Path( SEARCH_QUERY ) String emailSearchQuery );
-    
-    // Endpoints about roles
-    @POST( BASE + ROLES )
-    String createRole( @Body OrganizationRole role );
-
-    @GET( BASE + ROLES )
-    Iterable<OrganizationRole> getAllRoles();
-    
-    @GET( BASE + ROLES + ROLE_PATH )
-    List<Auth0UserBasic> getAllUsersOfRole( @Path( ROLE ) String roleIdString );
-
-    @PUT( BASE + ROLES + ROLE_PATH + TITLE )
-    Void updateTitle( @Path( ROLE ) String roleIdString, @Body String title );
-
-    @PUT( BASE + ROLES + ROLE_PATH + DESCRIPTION )
-    Void updateDescription( @Path( ROLE ) String roleIdString, @Body String description );
-
-    @DELETE( BASE + ROLES + ROLE_PATH )
-    Void deleteRole( @Path( ROLE ) String roleIdStrin );
-    
-    
 }

--- a/src/main/java/com/dataloom/directory/pojo/Auth0UserBasic.java
+++ b/src/main/java/com/dataloom/directory/pojo/Auth0UserBasic.java
@@ -22,7 +22,6 @@ public class Auth0UserBasic {
     private final String      email;
     private final String      nickname;
     private final String      username;
-    private final Set<String> roles;
     private final Set<String> organizations;
 
     @SuppressWarnings( "unchecked" )
@@ -44,9 +43,6 @@ public class Auth0UserBasic {
         } else {
             this.username = this.userId;
         }
-        this.roles = Sets.newHashSet(
-                ( (List<String>) MoreObjects.firstNonNull( appMetadata, new HashMap<>() ).getOrDefault( "roles",
-                        new ArrayList<String>() ) ) );
         this.organizations = Sets
                 .newHashSet( ( (List<String>) MoreObjects.firstNonNull( appMetadata, new HashMap<>() ).getOrDefault(
                         "organizations",
@@ -73,11 +69,6 @@ public class Auth0UserBasic {
         return username;
     }
 
-    @JsonProperty( ROLES_FIELD )
-    public Set<String> getRoles() {
-        return Collections.unmodifiableSet( roles );
-    }
-
     @JsonProperty( ORGANIZATIONS_FIELD )
     public Set<String> getOrganizations() {
         return Collections.unmodifiableSet( organizations );
@@ -89,7 +80,6 @@ public class Auth0UserBasic {
                 ", email='" + email + '\'' +
                 ", nickname='" + nickname + '\'' +
                 ", username='" + username + '\'' +
-                ", roles=" + roles +
                 ", organizations=" + organizations +
                 '}';
     }

--- a/src/main/java/com/dataloom/directory/pojo/Auth0UserBasic.java
+++ b/src/main/java/com/dataloom/directory/pojo/Auth0UserBasic.java
@@ -1,6 +1,7 @@
 package com.dataloom.directory.pojo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -22,6 +23,7 @@ public class Auth0UserBasic {
     private final String      email;
     private final String      nickname;
     private final String      username;
+    private final Set<String> roles;
     private final Set<String> organizations;
 
     @SuppressWarnings( "unchecked" )
@@ -43,6 +45,9 @@ public class Auth0UserBasic {
         } else {
             this.username = this.userId;
         }
+        this.roles = Sets.newHashSet(
+                ( (List<String>) MoreObjects.firstNonNull( appMetadata, new HashMap<>() ).getOrDefault( "roles",
+                        new ArrayList<String>() ) ) );
         this.organizations = Sets
                 .newHashSet( ( (List<String>) MoreObjects.firstNonNull( appMetadata, new HashMap<>() ).getOrDefault(
                         "organizations",
@@ -69,6 +74,11 @@ public class Auth0UserBasic {
         return username;
     }
 
+    @JsonIgnore
+    public Set<String> getRoles() {
+        return Collections.unmodifiableSet( roles );
+    }
+
     @JsonProperty( ORGANIZATIONS_FIELD )
     public Set<String> getOrganizations() {
         return Collections.unmodifiableSet( organizations );
@@ -80,6 +90,7 @@ public class Auth0UserBasic {
                 ", email='" + email + '\'' +
                 ", nickname='" + nickname + '\'' +
                 ", username='" + username + '\'' +
+                ", roles=" + roles +
                 ", organizations=" + organizations +
                 '}';
     }

--- a/src/main/java/com/dataloom/exceptions/ErrorDTO.java
+++ b/src/main/java/com/dataloom/exceptions/ErrorDTO.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017. Kryptnostic, Inc (dba Loom)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@thedataloom.com
+ */
+
+package com.dataloom.exceptions;
+
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ErrorDTO {
+    private LoomException error;
+    private String        message;
+
+    public ErrorDTO( LoomException error, String message ) {
+        this.error = error;
+        this.message = message;
+    }
+
+    @JsonProperty( SerializationConstants.ERROR )
+    public LoomException getError() {
+        return error;
+    }
+
+    @JsonProperty( SerializationConstants.MESSAGE )
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorDTO [error=" + error + ", message=" + message + "]";
+    }
+
+}

--- a/src/main/java/com/dataloom/exceptions/ErrorDTO.java
+++ b/src/main/java/com/dataloom/exceptions/ErrorDTO.java
@@ -23,16 +23,16 @@ import com.dataloom.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ErrorDTO {
-    private LoomException error;
+    private LoomExceptions error;
     private String        message;
 
-    public ErrorDTO( LoomException error, String message ) {
+    public ErrorDTO( LoomExceptions error, String message ) {
         this.error = error;
         this.message = message;
     }
 
     @JsonProperty( SerializationConstants.ERROR )
-    public LoomException getError() {
+    public LoomExceptions getError() {
         return error;
     }
 

--- a/src/main/java/com/dataloom/exceptions/ErrorsDTO.java
+++ b/src/main/java/com/dataloom/exceptions/ErrorsDTO.java
@@ -33,12 +33,12 @@ public class ErrorsDTO {
         this.errors = new ArrayList<ErrorDTO>();
     }
 
-    public ErrorsDTO( LoomException error, String message ) {
+    public ErrorsDTO( LoomExceptions error, String message ) {
         this();
         this.addError( error, message );
     }
 
-    public void addError( LoomException error, String message ) {
+    public void addError( LoomExceptions error, String message ) {
         errors.add( new ErrorDTO( error, message ) );
     }
 

--- a/src/main/java/com/dataloom/exceptions/ErrorsDTO.java
+++ b/src/main/java/com/dataloom/exceptions/ErrorsDTO.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017. Kryptnostic, Inc (dba Loom)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * You can contact the owner of the copyright at support@thedataloom.com
+ */
+
+package com.dataloom.exceptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ErrorsDTO {
+    private List<ErrorDTO> errors;
+
+    public ErrorsDTO() {
+        this.errors = new ArrayList<ErrorDTO>();
+    }
+
+    public ErrorsDTO( LoomException error, String message ) {
+        this();
+        this.addError( error, message );
+    }
+
+    public void addError( LoomException error, String message ) {
+        errors.add( new ErrorDTO( error, message ) );
+    }
+
+    @JsonProperty( SerializationConstants.ERRORS )
+    public List<ErrorDTO> getErrors() {
+        return errors;
+    }
+
+    public void setErrors( List<ErrorDTO> errors ) {
+        this.errors = errors;
+    }
+
+    @Override
+    public String toString() {
+        return "ErrorsDTO [errors=" + errors + "]";
+    }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return errors.isEmpty();
+    }
+}

--- a/src/main/java/com/dataloom/exceptions/LoomException.java
+++ b/src/main/java/com/dataloom/exceptions/LoomException.java
@@ -1,0 +1,38 @@
+package com.dataloom.exceptions;
+
+import java.net.HttpURLConnection;
+
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(
+    shape = JsonFormat.Shape.OBJECT )
+public enum LoomException {
+    RESOURCE_NOT_FOUND_EXCEPTION( "resourceNotFound", HttpURLConnection.HTTP_NOT_FOUND ),
+    ILLEGAL_ARGUMENT_EXCEPTION( "illegalArgument", HttpURLConnection.HTTP_BAD_REQUEST ),
+    ILLEGAL_STATE_EXCEPTION( "illegalState", HttpURLConnection.HTTP_INTERNAL_ERROR ),
+    TYPE_EXISTS_EXCEPTION( "typeExists", HttpURLConnection.HTTP_CONFLICT ),
+    FORBIDDEN_EXCEPTION( "forbidden", HttpURLConnection.HTTP_FORBIDDEN ),
+    TOKEN_REFRESH_EXCEPTION( "tokenNeedsRefresh", HttpURLConnection.HTTP_UNAUTHORIZED ),
+    AUTH0_TOKEN_EXCEPTION( "tokenError", HttpURLConnection.HTTP_UNAUTHORIZED ),
+    OTHER_EXCEPTION( "otherError", HttpURLConnection.HTTP_INTERNAL_ERROR );
+
+    private String type;
+    private int    code;
+
+    private LoomException( String type, int code ) {
+        this.type = type;
+        this.code = code;
+    }
+
+    @JsonProperty( SerializationConstants.TYPE_FIELD )
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty( SerializationConstants.HTTP_STATUS_CODE )
+    public int getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/dataloom/exceptions/LoomExceptions.java
+++ b/src/main/java/com/dataloom/exceptions/LoomExceptions.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonFormat(
     shape = JsonFormat.Shape.OBJECT )
-public enum LoomException {
+public enum LoomExceptions {
     RESOURCE_NOT_FOUND_EXCEPTION( "resourceNotFound", HttpURLConnection.HTTP_NOT_FOUND ),
     ILLEGAL_ARGUMENT_EXCEPTION( "illegalArgument", HttpURLConnection.HTTP_BAD_REQUEST ),
     ILLEGAL_STATE_EXCEPTION( "illegalState", HttpURLConnection.HTTP_INTERNAL_ERROR ),
@@ -21,7 +21,7 @@ public enum LoomException {
     private String type;
     private int    code;
 
-    private LoomException( String type, int code ) {
+    private LoomExceptions( String type, int code ) {
         this.type = type;
         this.code = code;
     }

--- a/src/main/java/com/dataloom/mapstores/TestDataFactory.java
+++ b/src/main/java/com/dataloom/mapstores/TestDataFactory.java
@@ -11,6 +11,7 @@ import com.dataloom.edm.type.Analyzer;
 import com.dataloom.edm.type.EntityType;
 import com.dataloom.edm.type.PropertyType;
 import com.dataloom.organization.Organization;
+import com.dataloom.organization.roles.RoleKey;
 import com.dataloom.requests.PermissionsRequestDetails;
 import com.dataloom.requests.RequestStatus;
 import com.dataloom.requests.Status;
@@ -194,5 +195,9 @@ public final class TestDataFactory {
 
     public static EntityKey entityKey() {
         return new EntityKey( UUID.randomUUID(), RandomStringUtils.random( 10 ) );
+    }
+    
+    public static RoleKey roleKey(){
+        return new RoleKey( UUID.randomUUID(), UUID.randomUUID() );
     }
 }

--- a/src/main/java/com/dataloom/organization/OrganizationsApi.java
+++ b/src/main/java/com/dataloom/organization/OrganizationsApi.java
@@ -1,10 +1,13 @@
 package com.dataloom.organization;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import com.dataloom.authorization.Principal;
 import com.dataloom.authorization.PrincipalType;
+import com.dataloom.directory.pojo.Auth0UserBasic;
+import com.dataloom.organization.roles.OrganizationRole;
 
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -39,6 +42,9 @@ public interface OrganizationsApi {
     String TYPE_PATH         = "/{" + TYPE + "}";
     String ROLES             = "/roles";
     String MEMBERS           = "/members";
+    
+    String ROLE_ID           = "roleId";
+    String ROLE_ID_PATH      = "/{" + ROLE_ID + "}";
 
     @GET( BASE )
     Iterable<Organization> getOrganizations();
@@ -138,9 +144,6 @@ public interface OrganizationsApi {
         path = BASE + ID_PATH + PRINCIPALS )
     Void removePrincipals( @Path( ID ) UUID organizationId, @Body Set<Principal> principals );
 
-    @GET( BASE + ID_PATH + PRINCIPALS + ROLES )
-    Set<Principal> getRoles( @Path( ID ) UUID organizationId );
-
     @GET( BASE + ID_PATH + PRINCIPALS + MEMBERS )
     Set<Principal> getMembers( @Path( ID ) UUID organizationId );
 
@@ -171,5 +174,33 @@ public interface OrganizationsApi {
             @Path( ID ) UUID organizationId,
             @Path( TYPE ) PrincipalType principalType,
             @Path( PRINCIPAL_ID ) String principalId );
+    
+    // Endpoints about roles
+    @POST( BASE + ROLES )
+    UUID createRole( @Body OrganizationRole role );
+
+    @GET( BASE + ID_PATH + PRINCIPALS + ROLES )
+    Iterable<OrganizationRole> getRoles( @Path( ID ) UUID organizationId );
+
+    @GET( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH )
+    OrganizationRole getRole( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId );
+
+    @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + TITLE )
+    Void updateTitle( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Body String title );
+
+    @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + DESCRIPTION )
+    Void updateDescription( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Body String description );
+
+    @DELETE( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH )
+    Void deleteRole( @Path( ID )UUID organizationId, @Path( ROLE_ID ) UUID roleId );    
+
+    @GET( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS )
+    Iterable<Auth0UserBasic> getAllUsersOfRole( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId );
+
+    @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS + PRINCIPAL_ID_PATH )
+    Void addRoleToUser( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Path( PRINCIPAL_ID ) String userId );
+
+    @DELETE( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS + PRINCIPAL_ID_PATH )
+    Void removeRoleFromUser( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Path( PRINCIPAL_ID ) String userId );
 
 }

--- a/src/main/java/com/dataloom/organization/OrganizationsApi.java
+++ b/src/main/java/com/dataloom/organization/OrganizationsApi.java
@@ -180,16 +180,16 @@ public interface OrganizationsApi {
     UUID createRole( @Body OrganizationRole role );
 
     @GET( BASE + ID_PATH + PRINCIPALS + ROLES )
-    Iterable<OrganizationRole> getRoles( @Path( ID ) UUID organizationId );
+    Iterable<Principal> getRoles( @Path( ID ) UUID organizationId );
 
     @GET( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH )
     OrganizationRole getRole( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId );
 
     @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + TITLE )
-    Void updateTitle( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Body String title );
+    Void updateRoleTitle( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Body String title );
 
     @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + DESCRIPTION )
-    Void updateDescription( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Body String description );
+    Void updateRoleDescription( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Body String description );
 
     @DELETE( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH )
     Void deleteRole( @Path( ID )UUID organizationId, @Path( ROLE_ID ) UUID roleId );    

--- a/src/main/java/com/dataloom/organization/OrganizationsApi.java
+++ b/src/main/java/com/dataloom/organization/OrganizationsApi.java
@@ -45,6 +45,8 @@ public interface OrganizationsApi {
     
     String ROLE_ID           = "roleId";
     String ROLE_ID_PATH      = "/{" + ROLE_ID + "}";
+    String USER_ID           = "userId";
+    String USER_ID_PATH      = "/{" + USER_ID + "}";
 
     @GET( BASE )
     Iterable<Organization> getOrganizations();
@@ -108,73 +110,16 @@ public interface OrganizationsApi {
     @GET( BASE + ID_PATH + PRINCIPALS )
     Set<Principal> getPrincipals( @Path( ID ) UUID organizationId );
 
-    /**
-     * This is a convenience call that modifies that grants {@code {@link com.dataloom.authorization.Permission#READ}}
-     * on the specified organization to the specified principals. A user's membership in an organization is determined
-     * by whether or not they have {@code {@link com.dataloom.authorization.Permission#READ}} on the organization.
-     *
-     * @param organizationId The id of the organization.
-     * @param principals A set of valid principals.
-     */
-    @POST( BASE + ID_PATH + PRINCIPALS )
-    Void addPrincipals( @Path( ID ) UUID organizationId, @Body Set<Principal> principals );
-
-    /**
-     * This is a convenience call that modifies that grants {@code {@link com.dataloom.authorization.Permission#READ}}
-     * on the specified organization to the specified principals. A user's membership in an organization is determined
-     * by whether or not they have {@code {@link com.dataloom.authorization.Permission#READ}} on the organization.
-     *
-     * @param organizationId The id of the organization.
-     * @param principals A set of valid principals.gs
-     * 
-     */
-    @PUT( BASE + ID_PATH + PRINCIPALS )
-    Void setPrincipals( @Path( ID ) UUID organizationId, @Body Set<Principal> principals );
-
-    /**
-     * This is a convenience call that modifies that removes all {@code {@link com.dataloom.authorization.Permission}}s
-     * that a principal may have on an organization, including discover.
-     *
-     * @param organizationId The id of the organization.
-     * @param principals A set of valid principals
-     */
-    @HTTP(
-        method = "DELETE",
-        hasBody = true,
-        path = BASE + ID_PATH + PRINCIPALS )
-    Void removePrincipals( @Path( ID ) UUID organizationId, @Body Set<Principal> principals );
-
+    //Endpoints about members
     @GET( BASE + ID_PATH + PRINCIPALS + MEMBERS )
     Set<Principal> getMembers( @Path( ID ) UUID organizationId );
 
-    /**
-     * This is a convenience call that grants {@code {@link com.dataloom.authorization.Permission#READ}} to a principal
-     * on an organization.
-     *
-     * @param organizationId The id of the organization.
-     * @param principalType The principal type of the principal being added.
-     * @param principalId The principalId of the principal being added.
-     */
-    @PUT( BASE + ID_PATH + PRINCIPALS + TYPE_PATH + PRINCIPAL_ID_PATH )
-    Void addPrincipal(
-            @Path( ID ) UUID organizationId,
-            @Path( TYPE ) PrincipalType principalType,
-            @Path( PRINCIPAL_ID ) String principalId );
+    @PUT( BASE + ID_PATH + PRINCIPALS + MEMBERS + USER_ID_PATH )
+    Void addMember( @Path( ID ) UUID organizationId, @Path( USER_ID ) String userId );
 
-    /**
-     * This is a convenience call that removes all {@code {@link com.dataloom.authorization.Permission}}s that a
-     * principal may have on an organization, including discover.
-     *
-     * @param organizationId The id of the organization.
-     * @param principalType The principal type of the principal being added.
-     * @param principalId The principalId of the principal being added.
-     */
-    @DELETE( BASE + ID_PATH + PRINCIPALS + TYPE_PATH + PRINCIPAL_ID_PATH )
-    Void removePrincipal(
-            @Path( ID ) UUID organizationId,
-            @Path( TYPE ) PrincipalType principalType,
-            @Path( PRINCIPAL_ID ) String principalId );
-    
+    @DELETE( BASE + ID_PATH + PRINCIPALS + MEMBERS + USER_ID_PATH )
+    Void removeMember( @Path( ID ) UUID organizationId, @Path( USER_ID ) String userId );
+
     // Endpoints about roles
     @POST( BASE + ROLES )
     UUID createRole( @Body OrganizationRole role );
@@ -197,10 +142,40 @@ public interface OrganizationsApi {
     @GET( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS )
     Iterable<Auth0UserBasic> getAllUsersOfRole( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId );
 
-    @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS + PRINCIPAL_ID_PATH )
-    Void addRoleToUser( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Path( PRINCIPAL_ID ) String userId );
+    @PUT( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS + USER_ID_PATH )
+    Void addRoleToUser( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Path( USER_ID ) String userId );
 
-    @DELETE( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS + PRINCIPAL_ID_PATH )
-    Void removeRoleFromUser( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Path( PRINCIPAL_ID ) String userId );
+    @DELETE( BASE + ID_PATH + PRINCIPALS + ROLES + ROLE_ID_PATH + MEMBERS + USER_ID_PATH )
+    Void removeRoleFromUser( @Path( ID ) UUID organizationId, @Path( ROLE_ID ) UUID roleId, @Path( USER_ID ) String userId );
+
+    /**
+     * This is a convenience call that grants {@code {@link com.dataloom.authorization.Permission#READ}} to a principal
+     * on an organization.
+     *
+     * @param organizationId The id of the organization.
+     * @param principalType The principal type of the principal being added.
+     * @param principalId The principalId of the principal being added.
+     */
+    @Deprecated
+    @PUT( BASE + ID_PATH + PRINCIPALS + TYPE_PATH + PRINCIPAL_ID_PATH )
+    Void addPrincipal(
+            @Path( ID ) UUID organizationId,
+            @Path( TYPE ) PrincipalType principalType,
+            @Path( PRINCIPAL_ID ) String principalId );
+
+    /**
+     * This is a convenience call that removes all {@code {@link com.dataloom.authorization.Permission}}s that a
+     * principal may have on an organization, including discover.
+     *
+     * @param organizationId The id of the organization.
+     * @param principalType The principal type of the principal being added.
+     * @param principalId The principalId of the principal being added.
+     */
+    @Deprecated
+    @DELETE( BASE + ID_PATH + PRINCIPALS + TYPE_PATH + PRINCIPAL_ID_PATH )
+    Void removePrincipal(
+            @Path( ID ) UUID organizationId,
+            @Path( TYPE ) PrincipalType principalType,
+            @Path( PRINCIPAL_ID ) String principalId );
 
 }

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -85,7 +85,7 @@ public class OrganizationRole extends AbstractSecurableObject {
      */
     public static UUID getOrganizationId( String stringRep ){
         try{
-            String[] splitted = stringRep.split( "|", 2);
+            String[] splitted = stringRep.split( "\\|", 2);
             return UUID.fromString( splitted[0] );
         } catch ( Exception e ){
             logger.error( "Error parsing organizationId from the string representation of role: " + stringRep );

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -6,19 +6,31 @@ import com.dataloom.authorization.Principal;
 import com.dataloom.authorization.PrincipalType;
 import com.dataloom.authorization.securable.AbstractSecurableObject;
 import com.dataloom.authorization.securable.SecurableObjectType;
+import com.dataloom.client.serialization.SerializationConstants;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
 public class OrganizationRole extends AbstractSecurableObject {
     private UUID      organizationId;
     private Principal principal;
 
-    public OrganizationRole( Optional<UUID> id, UUID organizationId, String title, Optional<String> description ) {
-        super( id, title, description );
-        this.organizationId = organizationId;
-        this.principal = new Principal( PrincipalType.ROLE, organizationId + "|" + title );
+    @JsonCreator
+    public OrganizationRole( 
+            @JsonProperty( SerializationConstants.ORGANIZATION_ID ) UUID organizationId, 
+            @JsonProperty( SerializationConstants.TITLE_FIELD ) String title, 
+            @JsonProperty( SerializationConstants.DESCRIPTION_FIELD ) Optional<String> description ) {
+        this( Optional.absent(), organizationId, title, description );
     }
 
+    public OrganizationRole( Optional<UUID> id, UUID organizationId, String title, Optional<String> description ){
+        super( id, title, description );
+        this.organizationId = organizationId;
+        this.principal = new Principal( PrincipalType.ROLE, this.id.toString() );        
+    }
+    
+    @JsonProperty( SerializationConstants.ORGANIZATION_ID )
     public UUID getOrganizationId() {
         return organizationId;
     }
@@ -33,4 +45,13 @@ public class OrganizationRole extends AbstractSecurableObject {
         return SecurableObjectType.OrganizationRole;
     }
 
+    @JsonIgnore
+    public String getRoleIdAsString(){
+        return id.toString();
+    }
+
+    @JsonIgnore
+    public static UUID getRoleIdFromString( String str ){
+        return UUID.fromString( str );
+    }
 }

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -3,6 +3,9 @@ package com.dataloom.organization.roles;
 import java.util.List;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.dataloom.authorization.Principal;
 import com.dataloom.authorization.PrincipalType;
 import com.dataloom.authorization.securable.AbstractSecurableObject;
@@ -20,6 +23,8 @@ import com.google.common.base.Optional;
  *
  */
 public class OrganizationRole extends AbstractSecurableObject {
+    private static final Logger logger = LoggerFactory.getLogger( OrganizationRole.class );
+
     private UUID      organizationId;
 
     private Principal principal;
@@ -73,5 +78,18 @@ public class OrganizationRole extends AbstractSecurableObject {
     
     public static String getStringRepresentation( UUID organizationId, String title ){
         return organizationId + "|" + title;
+    }
+    
+    /**
+     * This method must be consistent with {@link #getStringRepresentation(UUID, String)}
+     */
+    public static UUID getOrganizationId( String stringRep ){
+        try{
+            String[] splitted = stringRep.split( "|", 2);
+            return UUID.fromString( splitted[0] );
+        } catch ( Exception e ){
+            logger.error( "Error parsing organizationId from the string representation of role: " + stringRep );
+            throw new IllegalArgumentException( "Error parsing organizationId from the string representation of role: " + stringRep );
+        }
     }
 }

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -12,8 +12,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
+/**
+ * A role in an organization. Use both organizationId and roleId to specify a role.
+ * @author Ho Chung Siu
+ *
+ */
 public class OrganizationRole extends AbstractSecurableObject {
     private UUID      organizationId;
+
     private Principal principal;
 
     @JsonCreator
@@ -43,15 +49,5 @@ public class OrganizationRole extends AbstractSecurableObject {
     @Override
     public SecurableObjectType getCategory() {
         return SecurableObjectType.OrganizationRole;
-    }
-
-    @JsonIgnore
-    public String getRoleIdAsString(){
-        return id.toString();
-    }
-
-    @JsonIgnore
-    public static UUID getRoleIdFromString( String str ){
-        return UUID.fromString( str );
     }
 }

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -1,0 +1,36 @@
+package com.dataloom.organization.roles;
+
+import java.util.UUID;
+
+import com.dataloom.authorization.Principal;
+import com.dataloom.authorization.PrincipalType;
+import com.dataloom.authorization.securable.AbstractSecurableObject;
+import com.dataloom.authorization.securable.SecurableObjectType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.google.common.base.Optional;
+
+public class OrganizationRole extends AbstractSecurableObject {
+    private UUID      organizationId;
+    private Principal principal;
+
+    public OrganizationRole( Optional<UUID> id, UUID organizationId, String title, Optional<String> description ) {
+        super( id, title, description );
+        this.organizationId = organizationId;
+        this.principal = new Principal( PrincipalType.ROLE, organizationId + "|" + title );
+    }
+
+    public UUID getOrganizationId() {
+        return organizationId;
+    }
+
+    @JsonIgnore
+    public Principal getPrincipal() {
+        return principal;
+    }
+
+    @Override
+    public SecurableObjectType getCategory() {
+        return SecurableObjectType.OrganizationRole;
+    }
+
+}

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -1,5 +1,6 @@
 package com.dataloom.organization.roles;
 
+import java.util.List;
 import java.util.UUID;
 
 import com.dataloom.authorization.Principal;
@@ -14,6 +15,7 @@ import com.google.common.base.Optional;
 
 /**
  * A role in an organization. Use both organizationId and roleId to specify a role.
+ * 
  * @author Ho Chung Siu
  *
  */
@@ -21,21 +23,23 @@ public class OrganizationRole extends AbstractSecurableObject {
     private UUID      organizationId;
 
     private Principal principal;
+    private RoleKey   roleKey;
 
     @JsonCreator
-    public OrganizationRole( 
-            @JsonProperty( SerializationConstants.ORGANIZATION_ID ) UUID organizationId, 
-            @JsonProperty( SerializationConstants.TITLE_FIELD ) String title, 
+    public OrganizationRole(
+            @JsonProperty( SerializationConstants.ORGANIZATION_ID ) UUID organizationId,
+            @JsonProperty( SerializationConstants.TITLE_FIELD ) String title,
             @JsonProperty( SerializationConstants.DESCRIPTION_FIELD ) Optional<String> description ) {
         this( Optional.absent(), organizationId, title, description );
     }
 
-    public OrganizationRole( Optional<UUID> id, UUID organizationId, String title, Optional<String> description ){
+    public OrganizationRole( Optional<UUID> id, UUID organizationId, String title, Optional<String> description ) {
         super( id, title, description );
         this.organizationId = organizationId;
-        this.principal = new Principal( PrincipalType.ROLE, this.id.toString() );        
+        this.roleKey = new RoleKey( organizationId, this.id );
+        this.principal = new Principal( PrincipalType.ROLE, this.roleKey.toString() );
     }
-    
+
     @JsonProperty( SerializationConstants.ORGANIZATION_ID )
     public UUID getOrganizationId() {
         return organizationId;
@@ -44,6 +48,20 @@ public class OrganizationRole extends AbstractSecurableObject {
     @JsonIgnore
     public Principal getPrincipal() {
         return principal;
+    }
+
+    @JsonIgnore
+    public RoleKey getRoleKey() {
+        return roleKey;
+    }
+
+    /**
+     * Convenience method to retrieve acl key for this role
+     * @return
+     */
+    @JsonIgnore
+    public List<UUID> getAclKey() {
+        return roleKey.getAclKey();
     }
 
     @Override

--- a/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
+++ b/src/main/java/com/dataloom/organization/roles/OrganizationRole.java
@@ -27,17 +27,14 @@ public class OrganizationRole extends AbstractSecurableObject {
 
     @JsonCreator
     public OrganizationRole(
+            @JsonProperty( SerializationConstants.ID_FIELD ) Optional<UUID> id,
             @JsonProperty( SerializationConstants.ORGANIZATION_ID ) UUID organizationId,
             @JsonProperty( SerializationConstants.TITLE_FIELD ) String title,
             @JsonProperty( SerializationConstants.DESCRIPTION_FIELD ) Optional<String> description ) {
-        this( Optional.absent(), organizationId, title, description );
-    }
-
-    public OrganizationRole( Optional<UUID> id, UUID organizationId, String title, Optional<String> description ) {
         super( id, title, description );
         this.organizationId = organizationId;
         this.roleKey = new RoleKey( organizationId, this.id );
-        this.principal = new Principal( PrincipalType.ROLE, this.roleKey.toString() );
+        this.principal = new Principal( PrincipalType.ROLE, getStringRepresentation( organizationId, title ) );
     }
 
     @JsonProperty( SerializationConstants.ORGANIZATION_ID )
@@ -67,5 +64,14 @@ public class OrganizationRole extends AbstractSecurableObject {
     @Override
     public SecurableObjectType getCategory() {
         return SecurableObjectType.OrganizationRole;
+    }
+    
+    @Override
+    public String toString() {
+        return getStringRepresentation( organizationId, title );
+    }
+    
+    public static String getStringRepresentation( UUID organizationId, String title ){
+        return organizationId + "|" + title;
     }
 }

--- a/src/main/java/com/dataloom/organization/roles/RoleKey.java
+++ b/src/main/java/com/dataloom/organization/roles/RoleKey.java
@@ -1,0 +1,35 @@
+package com.dataloom.organization.roles;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+public class RoleKey {
+    private UUID       organizationId;
+    private UUID       roleId;
+
+    private List<UUID> aclKey;
+
+    public RoleKey( UUID organizationId, UUID roleId ) {
+        this.organizationId = organizationId;
+        this.roleId = roleId;
+        aclKey = Arrays.asList( organizationId, roleId );
+    }
+
+    public UUID getOrganizationId() {
+        return organizationId;
+    }
+
+    public UUID getRoleId() {
+        return roleId;
+    }
+
+    public List<UUID> getAclKey() {
+        return aclKey;
+    }
+
+    @Override
+    public String toString() {
+        return organizationId + "|" + roleId;
+    }
+}

--- a/src/main/java/com/dataloom/organization/roles/RoleKey.java
+++ b/src/main/java/com/dataloom/organization/roles/RoleKey.java
@@ -27,9 +27,4 @@ public class RoleKey {
     public List<UUID> getAclKey() {
         return aclKey;
     }
-
-    @Override
-    public String toString() {
-        return organizationId + "|" + roleId;
-    }
 }


### PR DESCRIPTION
Roles Service
- refactor OrganizationsController to implement CRUD endpoints for roles and add/remove users to roles.
- refactor PrincipalsDirectoryController to remove role endpoints
- refactor ExceptionHandling; created LoomException enum rather than ad-hoc string messages; specified serialization of `ErrorDTO` and `ErrorsDTO`

**Reason for not merging**
- This PR is interfered by the earlier rhizome request that deletes IMap entry if the (collection) value is empty. As a result, creating a role, add a member to the role then remove the member from that role would delete the relevant entry in the `roles` table, causing inconsistency.
- Prod server time has to match Auth0 server time.
- Token would be invalidated if there are role changes. Unless frontend changes for refreshing token is in place, this would force user to log out and log back in manually every time the token is invalidated. (The whole PR itself is compatible with the current UI though)