### PR TITLE
make MetadataUpdate Serializable

### DIFF
--- a/src/main/java/com/dataloom/edm/requests/MetadataUpdate.java
+++ b/src/main/java/com/dataloom/edm/requests/MetadataUpdate.java
@@ -1,6 +1,5 @@
 package com.dataloom.edm.requests;
 
-import java.io.Serializable;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -19,8 +18,7 @@ import com.google.common.base.Preconditions;
  * @author Ho Chung Siu
  *
  */
-public class MetadataUpdate implements Serializable {
-    private static final long serialVersionUID = 5732378212397360336L;
+public class MetadataUpdate {
     // Common across property type, entity type, entity set
     private Optional<String>            title;
     private Optional<String>            description;

--- a/src/main/java/com/dataloom/edm/requests/MetadataUpdate.java
+++ b/src/main/java/com/dataloom/edm/requests/MetadataUpdate.java
@@ -80,6 +80,42 @@ public class MetadataUpdate implements Serializable {
         return type;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( contacts == null ) ? 0 : contacts.hashCode() );
+        result = prime * result + ( ( description == null ) ? 0 : description.hashCode() );
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        result = prime * result + ( ( title == null ) ? 0 : title.hashCode() );
+        result = prime * result + ( ( type == null ) ? 0 : type.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals( Object obj ) {
+        if ( this == obj ) return true;
+        if ( obj == null ) return false;
+        if ( getClass() != obj.getClass() ) return false;
+        MetadataUpdate other = (MetadataUpdate) obj;
+        if ( contacts == null ) {
+            if ( other.contacts != null ) return false;
+        } else if ( !contacts.equals( other.contacts ) ) return false;
+        if ( description == null ) {
+            if ( other.description != null ) return false;
+        } else if ( !description.equals( other.description ) ) return false;
+        if ( name == null ) {
+            if ( other.name != null ) return false;
+        } else if ( !name.equals( other.name ) ) return false;
+        if ( title == null ) {
+            if ( other.title != null ) return false;
+        } else if ( !title.equals( other.title ) ) return false;
+        if ( type == null ) {
+            if ( other.type != null ) return false;
+        } else if ( !type.equals( other.type ) ) return false;
+        return true;
+    }
+
     // Trimming happens before initializing update processors so that irrelevant fields won't get ser/deserialized when
     // processors are serialized.
     public static MetadataUpdate trimToPropertyTypeUpdate( MetadataUpdate update ) {
@@ -108,5 +144,4 @@ public class MetadataUpdate implements Serializable {
                 update.getContacts(),
                 Optional.absent() );
     }
-
 }

--- a/src/main/java/com/dataloom/edm/requests/MetadataUpdate.java
+++ b/src/main/java/com/dataloom/edm/requests/MetadataUpdate.java
@@ -1,5 +1,6 @@
 package com.dataloom.edm.requests;
 
+import java.io.Serializable;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -18,7 +19,8 @@ import com.google.common.base.Preconditions;
  * @author Ho Chung Siu
  *
  */
-public class MetadataUpdate {
+public class MetadataUpdate implements Serializable {
+    private static final long serialVersionUID = 5732378212397360336L;
     // Common across property type, entity type, entity set
     private Optional<String>            title;
     private Optional<String>            description;


### PR DESCRIPTION
`UpdatePropertyTypeMetadataProcessor`, `UpdateEntityTypeMetadataProcessor` and `UpdateEntitySetMetadataProcessor` has `MetadataUpdate` as a field, which is not serializable (but those processors have stream serializers already). 

findBugs doesn't like this, and it's breaking conductor-client's build